### PR TITLE
Get data from url and add caching

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/notes.txt
+++ b/notes.txt
@@ -29,7 +29,11 @@ https://stackoverflow.com/questions/71090111/how-to-draw-on-jetpack-compose-canv
 https://stackoverflow.com/questions/67185495/draw-two-buttons-in-a-row-using-jetpack-compose
 https://stackoverflow.com/questions/58743541/how-to-get-context-in-jetpack-compose
 https://stackoverflow.com/questions/68909340/how-to-show-snackbar-with-a-button-onclick-in-jetpack-compose
+https://stackoverflow.com/questions/47971972/how-to-properly-use-the-url-with-kotlin-android
+https://developer.android.com/training/data-storage/app-specific#internal-access-files
+https://stackoverflow.com/questions/34964337/write-data-to-local-json-file
+https://stackoverflow.com/questions/47971972/how-to-properly-use-the-url-with-kotlin-android
+https://stackoverflow.com/questions/77550167/how-to-update-ui-on-async-callbacks-in-jetpack-compose
 
 TODO:
 - guessing game mode?
-- still need to fix drawing on the canvas

--- a/notes.txt
+++ b/notes.txt
@@ -34,6 +34,7 @@ https://developer.android.com/training/data-storage/app-specific#internal-access
 https://stackoverflow.com/questions/34964337/write-data-to-local-json-file
 https://stackoverflow.com/questions/47971972/how-to-properly-use-the-url-with-kotlin-android
 https://stackoverflow.com/questions/77550167/how-to-update-ui-on-async-callbacks-in-jetpack-compose
+https://stackoverflow.com/questions/75762170/how-can-i-access-a-json-file-in-the-viewmodel-class
 
 TODO:
 - guessing game mode?


### PR DESCRIPTION
this PR makes it so that Chinese flashcard data is now pulled, if possible, from the latest JSON file off the main branch of https://github.com/syncopika/flashcards so I can stop having to update the same data in 2 places lol. the freshest data is also cached to an app-specific local file and will be read from if there's no internet connection. 

one negative thing to note about this new approach is that the flashcard data doesn't immediately show when the app is loaded if there is internet available because the data via the url is fetched asynchronously and I haven't yet figured out how to get it so that the UI will re-render once the data is fetched (need to use a ViewModel I guess?). to remedy this for now, I've added a refresh button under the shuffle button in the drawer which seems to work well enough.

some log screenshots of when there's internet vs no internet
internet available:
> ![flashcards-app-internet](https://github.com/user-attachments/assets/51938a8c-7e6c-4849-8be9-2a89b69a5c5d)


no internet:
> ![flashcards-app-no-internet-logs](https://github.com/user-attachments/assets/c40298b8-2bcd-4a2a-abe2-e10c051b6f53)
