### PR TITLE
Add view model for data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This app currently just has cards for Chinese and Japanese, which is based off h
     
 You can traverse the cards by swiping left and right. Tapping on the card will flip it. You can also search for a specific card based on the card text.   
     
+![screen recording of app](screenshots/screen-20251207-063511.mp4)    
+    
 some screenshots:    
 ![screenshot of flashcard front](screenshots/Screenshot_20240105-212644.png)   
 ![screenshot of flashcard back](screenshots/Screenshot_20240105-212702.png)     

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation ("androidx.compose.runtime:runtime-livedata:1.5.0")
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.google.mlkit:digital-ink-recognition:18.1.0")
     implementation("androidx.compose.material3:material3-android:1.2.1")

--- a/app/src/main/java/com/example/flashcards/MainActivity.kt
+++ b/app/src/main/java/com/example/flashcards/MainActivity.kt
@@ -58,7 +58,7 @@ import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -75,8 +75,9 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.zIndex
-import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.flashcards.ui.theme.DrawingCanvas
 import com.example.flashcards.ui.theme.FlashcardsTheme
 import com.google.gson.Gson
@@ -161,38 +162,43 @@ fun filterCardsJapanese(cards: Array<Any>, searchType: String, searchText: Strin
         }
     }.toTypedArray()
 }
+// ViewModel class for getting the flashcard data
+// https://developer.android.com/topic/libraries/architecture/viewmodel
+// https://stackoverflow.com/questions/44318859/fetching-a-url-in-android-kotlin-asynchronously
+// https://medium.com/@rzmeneghelo/building-a-jetpack-compose-view-with-viewmodel-9c8aca9795f4
+// this looks helpful? https://www.kodeco.com/24509368-repository-pattern-with-jetpack-compose
+// https://stackoverflow.com/questions/69034492/viewmodel-data-lost-on-rotation
+class FlashcardDataViewModel(context: Context) : ViewModel() {
+    val chineseJson = MutableLiveData<Array<Any>>()
+    //val japaneseJSON = MutableLiveData(emptyArray<Any>()) // TODO
 
-class MainActivity : ComponentActivity() {
-    @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    // the name of the local file to cache
+    private val localChineseDataFilename = "flashcards_chinese_data.json"
 
-        // TODO: use a viewmodel for the data? - see https://developer.android.com/topic/libraries/architecture/viewmodel
-        // https://stackoverflow.com/questions/44318859/fetching-a-url-in-android-kotlin-asynchronously
+    private val ctx = context
 
-        val gson = Gson()
+    private val gson = Gson()
 
-        var chineseJson = emptyArray<Any>() // will be fetched from latest version of JSON data via url
-
-        val japaneseData: String = assets.open("japanese.json").bufferedReader().use { it.readText() }
-        val japaneseJson = gson.fromJson(japaneseData, Array<JapaneseJSONObject>::class.java) as Array<Any>
-
-        // the name of the local file to cache
-        val localChineseDataFilename = "flashcards_chinese_data.json"
-
+    // this method gets our json data for the flashcards
+    fun fetchData(){
         // try fetching chinese data json via url and add to cache
         val hasInternet = this.isConnectedToInternet()
         if (hasInternet) {
-            lifecycleScope.launch {
+            viewModelScope.launch {
                 Log.i("INFO", "attempting to get chinese data from url...")
                 withContext(Dispatchers.IO) {
-                    val json =
-                        URL("https://raw.githubusercontent.com/syncopika/flashcards/refs/heads/main/public/datasets/chinese.json").readText()
-                    chineseJson = gson.fromJson(json, Array<ChineseJSONObject>::class.java) as Array<Any>
+                    val json = URL("https://raw.githubusercontent.com/syncopika/flashcards/refs/heads/main/public/datasets/chinese.json").readText()
+
+                    // https://stackoverflow.com/questions/53304347/mutablelivedata-cannot-invoke-setvalue-on-a-background-thread-from-coroutine
+                    chineseJson.postValue(gson.fromJson(json, Array<ChineseJSONObject>::class.java) as Array<Any>)
+
                     Log.i("INFO", "got chinese data from url!")
 
                     // write data to cache
-                    applicationContext.openFileOutput(localChineseDataFilename, Context.MODE_PRIVATE).use {
+                    ctx.openFileOutput(
+                        localChineseDataFilename,
+                        Context.MODE_PRIVATE
+                    ).use {
                         Log.i("INFO", "writing chinese data to cache...")
                         it.write(json.toByteArray())
                     }
@@ -200,18 +206,53 @@ class MainActivity : ComponentActivity() {
             }
         } else {
             // if that doesn't work, use the cache
-            val file = File(applicationContext.filesDir, localChineseDataFilename)
+            val file = File(ctx.filesDir, localChineseDataFilename)
             if (file.exists()) {
                 Log.i("INFO", "no internet, pulling data from cache...")
-                val chineseData: String = applicationContext.openFileInput(localChineseDataFilename).bufferedReader().use { it.readText() }
-                chineseJson = gson.fromJson(chineseData, Array<ChineseJSONObject>::class.java) as Array<Any>
+                val chineseData: String = ctx.openFileInput(localChineseDataFilename).bufferedReader().use { it.readText() }
+                chineseJson.value = gson.fromJson(chineseData, Array<ChineseJSONObject>::class.java) as Array<Any>
             } else {
                 // no cached file, just use asset file (might be outdated though)
                 Log.i("INFO", "no internet + no cached file, using data from /assets")
-                val chineseData: String = assets.open("chinese.json").bufferedReader().use { it.readText() }
-                chineseJson = gson.fromJson(chineseData, Array<ChineseJSONObject>::class.java) as Array<Any>
+                val chineseData: String = ctx.assets.open("chinese.json").bufferedReader().use { it.readText() }
+                chineseJson.value = gson.fromJson(chineseData, Array<ChineseJSONObject>::class.java) as Array<Any>
             }
         }
+    }
+
+    private fun isConnectedToInternet(): Boolean {
+        val connManager = ctx.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        if (connManager != null) {
+            val netCapabilities = connManager.getNetworkCapabilities(connManager.activeNetwork)
+            if(netCapabilities != null){
+                if(netCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)){
+                    return true
+                }else if(netCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)){
+                    return true
+                }else if(netCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)){
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // TODO: viewModel should be stored so it persists when rotating phone?
+        val viewModel = FlashcardDataViewModel(applicationContext)
+
+        val gson = Gson()
+
+        val japaneseData: String = assets.open("japanese.json").bufferedReader().use { it.readText() }
+        val japaneseJson = gson.fromJson(japaneseData, Array<JapaneseJSONObject>::class.java) as Array<Any>
+
+        // use view model for getting flashcard data
+        viewModel.fetchData()
 
         setContent {
             FlashcardsTheme() {
@@ -227,6 +268,15 @@ class MainActivity : ComponentActivity() {
                 val (selectedOption, onOptionSelected) = remember { mutableStateOf(searchOptions.value[0]) }
 
                 // when the list of filtered cards changes, the view should be updated accordingly
+                val chineseJsonData by viewModel.chineseJson.observeAsState()
+                var chineseJson = chineseJsonData
+                if(chineseJson == null){
+                    Log.i("DEBUG", "chinese json data is null")
+                    chineseJson = emptyArray()
+                } else {
+                    Log.i("DEBUG", "got chinese json data")
+                }
+
                 var filteredCards by remember { mutableStateOf(chineseJson.copyOf()) }
                 var currIndex by remember { mutableStateOf(0) }
 
@@ -305,9 +355,17 @@ class MainActivity : ComponentActivity() {
                                                         onOptionSelected(text)
 
                                                         if (currFlashcardLanguage == "chinese") {
-                                                            filteredCards = filterCardsChinese(chineseJson, text, searchText)
+                                                            filteredCards = filterCardsChinese(
+                                                                chineseJson,
+                                                                text,
+                                                                searchText
+                                                            )
                                                         } else {
-                                                            filteredCards = filterCardsJapanese(japaneseJson, text, searchText)
+                                                            filteredCards = filterCardsJapanese(
+                                                                japaneseJson,
+                                                                text,
+                                                                searchText
+                                                            )
                                                         }
 
                                                         currIndex = 0
@@ -331,10 +389,17 @@ class MainActivity : ComponentActivity() {
                                 }
                                 
                                 Button(onClick = {
-                                    filteredCards.shuffle()
-                                    currIndex = Random.nextInt(0, filteredCards.size)
-                                    scope.launch {
-                                        snackbarHostState.showSnackbar("shuffled!", null, false, SnackbarDuration.Short)
+                                    if(filteredCards.size > 1){
+                                        filteredCards.shuffle()
+                                        currIndex = Random.nextInt(0, filteredCards.size)
+                                        scope.launch {
+                                            snackbarHostState.showSnackbar(
+                                                "shuffled!",
+                                                null,
+                                                false,
+                                                SnackbarDuration.Short
+                                            )
+                                        }
                                     }
                                 }) {
                                     Text("shuffle")

--- a/app/src/main/java/com/example/flashcards/MainActivity.kt
+++ b/app/src/main/java/com/example/flashcards/MainActivity.kt
@@ -70,7 +70,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
@@ -263,6 +262,7 @@ class MainActivity : ComponentActivity() {
 
                 val scope = rememberCoroutineScope()
 
+                var filteredCards by remember { mutableStateOf(emptyArray<Any>()) }
                 var searchText by remember { mutableStateOf("") }
                 var searchOptions = remember { mutableStateOf(listOf("front", "back", "pinyin", "tag")) }
                 val (selectedOption, onOptionSelected) = remember { mutableStateOf(searchOptions.value[0]) }
@@ -277,7 +277,7 @@ class MainActivity : ComponentActivity() {
                     Log.i("DEBUG", "got chinese json data")
                 }
 
-                var filteredCards by remember { mutableStateOf(chineseJson.copyOf()) }
+                filteredCards = chineseJson.copyOf() // update filteredCards to be the new data we got via the view model
                 var currIndex by remember { mutableStateOf(0) }
 
                 var showDrawingCanvas by remember { mutableStateOf(false) }


### PR DESCRIPTION
This PR adds a view model for data fetching! currently it only gets the Chinese flashcard data. 

The view model helps with:
- abstracting away logic related only to data fetching from MainActivity 
- getting the UI to update accordingly when we've successfully fetched our Chinese flashcard data asynchronously (via url)
  - the key thing here is that we can use the view model in our main activity, observe changes on the Chinese json data in the view model and update our `filteredCards` mutable state within our `FlashcardsTheme` composable when we've gotten the data. but it's important to only do that once when the data is loaded (I added the `chineseDataLoaded` flag to help with that).

As a result of the UI auto-refreshing when we get the chinese flashcard data, I was able to remove that refresh button in the drawer :D.

<img width="280" height="600" alt="Screenshot_20251207-061212" src="https://github.com/user-attachments/assets/d16fc29b-6ff5-461a-a1f2-96fcd107b5d4" />


I also fixed a bug with the shuffle functionality where I wasn't taking into account the possibility of the size of data being 0, which would mess up `Random.nextInt`.

Screen recording of everything working:

https://github.com/user-attachments/assets/199c1e7b-8c0f-4142-9f26-6fd367e45193



